### PR TITLE
Fix for issue 22703 - Message Preview Now Clears

### DIFF
--- a/tools/release
+++ b/tools/release
@@ -110,7 +110,7 @@ export OUTPUT_DIR
 
 ./tools/build-release-tarball "$version"
 
-TARBALL="$OUTDIR/zulip-server-$version.tar.gz"
+TARBALL="$OUTPUT_DIR/zulip-server-$version.tar.gz"
 if ! [ -f "$TARBALL" ]; then
     echo "Did not find expected $TARBALL!"
     exit 1


### PR DESCRIPTION
Fix for the message preview not clearing when clicking on a new topic and message. Added a call to "clear_preview_area()" in compose_actions.js which also changes the message area state to the compose state instead of the preview state.

Fixes: (https://github.com/zulip/zulip/issues/22703)

Screencap: https://user-images.githubusercontent.com/21269876/185985793-3fcf312b-bbcc-46fa-8bb9-d837d5a367a2.mov

- [ X ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ X ] Each commit is a coherent idea.
- [ X ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ X ] Visual appearance of the changes.
- [ X ] Responsiveness and internationalization.
- [ X ] Strings and tooltips.
- [ X ] End-to-end functionality of buttons, interactions and flows.
- [ X ] Corner cases, error conditions, and easily imagined bugs.
